### PR TITLE
Added workaround solution to the 'Overriding non-@objc declarations from extensions is not supported' issue in Xcode 9.3

### DIFF
--- a/Source/AnimatedImage.swift
+++ b/Source/AnimatedImage.swift
@@ -7,6 +7,16 @@ import ImageIO
 import Gifu
 import Nuke
 
+extension UIImage {
+    
+    /// 'required' initializer 'init(imageLiteralResourceName:)' must be provided by subclass of 'UIImage', but
+    /// overriding non-@objc declarations from extensions is not supported. Hence this extension to workaround
+    /// the issue
+    @objc public convenience init(imageLiteralResourceName name: String) {
+        fatalError("init(imageLiteralResourceName:) has not been implemented")
+    }
+}
+
 /// Represents animated image data alongside a poster image (first image frame).
 public class AnimatedImage: UIImage {
     public let data: Data


### PR DESCRIPTION
Hi @kean

"Overriding non-@objc declarations from extensions is not supported"

I ran into this issue this morning while upgrading our app code base to Swift 4.1. I see someone else also reported the same issue. Please review and let me know if this is a workable temporary solution

Thanks